### PR TITLE
feat(): install docker compose v2

### DIFF
--- a/ubuntu/installDocker.bash
+++ b/ubuntu/installDocker.bash
@@ -12,6 +12,10 @@ apt update -y -qq
 apt-get install docker-ce docker-ce-cli containerd.io -y -qq
 apt update -y -qq
 apt upgrade -y -qq
+#install Docker Compose V2
+mkdir -p ~/.docker/cli-plugins/
+curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+chmod +x ~/.docker/cli-plugins/docker-compose
 #change docker default log policy
 echo "{
     \"log-driver\": \"json-file\",


### PR DESCRIPTION
## Changes:
* Install Docker Compose V2 cli plugin (requirement for docker swarm on-premises DevOps Center deployments)