### PR TITLE
Documentation about how to configure a customer infrastructure to use a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,47 @@ parameters=""
 
 curl -fsSL https://raw.githubusercontent.com/criticalmanufacturing/install-scripts/main/ubuntu/portal/initializeInfrastructure.bash | sudo bash -s -- --agent "$agent" --infrastructure "$infrastructure" --infrastructureTemplate "$infrastructureTemplate" --environmentType "$environmentType" --internetNetworkName "$internetNetworkName" --portalToken "$portalToken" --parameters "$parameters"
 ```
+
+
+## Configure customer infrastructure to use a Proxy
+
+When you want to use a Proxy and configure a infrastructure/machine to pass all the connections through a proxy, some troubles can appear to be possible to communicate with the external network and get the necessary packages and images from the registry. You must set some environment variables on your system, to permit your machine to communicate through your proxy and access the external network to download the essencial packages and others.
+
+Assuming you are using a linux machine (for windows you must try achive the same goal, creating environemnt variables and configuring the docker daemon), you must run something like the next command lines to add the necessary environment variables (with values replaced) to your system.
+
+```bash
+export "HTTP_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>"
+export "HTTPS_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>"
+```
+
+Depending on the software or system, can be necessary you add the same environment variables in lower case to, like http_proxy and https_proxy.
+
+After this, your system must be able to update the current packages and get new ones, this is, all the necessary packages to deploy a customer infrastructure on your machine (the sections and scripts discussed above), in this case for example docker, portainer and powershell. 
+
+The next part of this topic is about how to configure your docker daemon from your infrastructure to use your defined proxy (the docker is mandatory), because probably you may need some changes/configurations to make the docker pass through your proxy. 
+
+The best solution to make the docker respect your proxy configurations is present on the [docker documentation](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy), where is explained the solution assuming you are using a linux machine. Summing up, for a regular installation the steps are the follows: 
+1. Create directory for docker service 
+```bash
+sudo mkdir -p /etc/systemd/system/docker.service.d
+```
+
+2. Create a file named *http-proxy.conf* on the previous directory (/etc/systemd/system/docker.service.d/http-proxy.conf)
+
+3. Add your proxy configuration like environment variables (see the next example) on the created file.
+```docker
+[Service]
+Environment="HTTP_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>"
+Environment="HTTPS_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>"
+```
+
+4. Restart your docker daemon to apply your configurations
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+```
+
+5. To check your docker configurations
+```bash
+sudo systemctl show --property=Environment docker
+```

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Depending on the software or system, can be necessary you add the same environme
 To define this variables to all your system, you can define on the file */etc/apt/apt.conf* (in some system on another place like */etc/apt/apt.conf.d/{something-proxy}*) the following code:
 
 ```bash
-Acquire::http:proxy http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>/";
-Acquire::https:proxy http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>/";
+Acquire::http:proxy "http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>/";
+Acquire::https:proxy "http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>/";
 ```
 
 After this, your system must be able to update the current packages and get new ones, this is, all the necessary packages to deploy a customer infrastructure on your machine (the sections and scripts discussed above), in this case for example docker, portainer and powershell. 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,28 @@ curl -fsSL https://raw.githubusercontent.com/criticalmanufacturing/install-scrip
 
 When you want to use a Proxy and configure a infrastructure/machine to pass all the connections through a proxy, some troubles can appear to be possible to communicate with the external network and get the necessary packages and images from the registry. You must set some environment variables on your system, to permit your machine to communicate through your proxy and access the external network to download the essencial packages and others.
 
-Assuming you are using a linux machine (for windows you must try achive the same goal, creating environemnt variables and configuring the docker daemon), you must run something like the next command lines to add the necessary environment variables (with values replaced) to your system.
+Assuming you are using a linux machine (for windows you must try achive the same goal, creating environemnt variables and configuring the docker daemon), you can add this next export commands lines on your */etc/bash.bashrc* (for your bash start with this environment variables) or do you just run. The idea is to add the necessary environment variables to your system.
 
 ```bash
 export "HTTP_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>"
 export "HTTPS_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>"
 ```
 
-Depending on the software or system, can be necessary you add the same environment variables in lower case to, like http_proxy and https_proxy.
+Or to set in your environment variables file (*/etc/environment*) below the PATH environment:
+
+```bash
+HTTP_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>
+HTTPS_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>
+```
+
+Depending on the software or system, can be necessary you add the same environment variables in lower case to, this is 'http_proxy' and 'https_proxy'.
+
+To define this variables to all your system, you can define on the file */etc/apt/apt.conf* (in some system on another place like */etc/apt/apt.conf.d/{something-proxy}*) the following code:
+
+```bash
+Acquire::http:proxy http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>/";
+Acquire::https:proxy http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>/";
+```
 
 After this, your system must be able to update the current packages and get new ones, this is, all the necessary packages to deploy a customer infrastructure on your machine (the sections and scripts discussed above), in this case for example docker, portainer and powershell. 
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ curl -fsSL https://raw.githubusercontent.com/criticalmanufacturing/install-scrip
 
 ## Configure customer infrastructure to use a Proxy
 
-When you want to use a Proxy and configure a infrastructure/machine to pass all the connections through a proxy, some troubles can appear to be possible to communicate with the external network and get the necessary packages and images from the registry. You must set some environment variables on your system, to permit your machine to communicate through your proxy and access the external network to download the essencial packages and others.
+When you want to use a Proxy and configure a infrastructure/machine to pass all the connections through a proxy, there are additional configurations that need to be performed to be able to communicate with the external network and get the necessary packages and images from the registry. You must set some environment variables on your system, to permit your machine to communicate through your proxy and access the external network to download the essencial packages and others.
 
-Assuming you are using a linux machine (for windows you must try achive the same goal, creating environemnt variables and configuring the docker daemon), you can add this next export commands lines on your */etc/bash.bashrc* (for your bash start with this environment variables) or do you just run. The idea is to add the necessary environment variables to your system.
+For Linux machines, add the following export commands lines on your /etc/bash.bashrc, ensuring that bash will start with additional environment variables. The goal is to add the necessary environment variables to your system. For Windows machines you can try achive the same goal by creating environemnt variables and configuring the docker daemon.
 
 ```bash
 export "HTTP_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>"
@@ -126,9 +126,9 @@ HTTP_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>
 HTTPS_PROXY=http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>
 ```
 
-Depending on the software or system, can be necessary you add the same environment variables in lower case to, this is 'http_proxy' and 'https_proxy'.
+Depending on the software or system, it can be necessary you add the same environment variables in lower case to, this is 'http_proxy' and 'https_proxy'.
 
-To define this variables to all your system, you can define on the file */etc/apt/apt.conf* (in some system on another place like */etc/apt/apt.conf.d/{something-proxy}*) the following code:
+To define this variables to all your system, you can define on the file */etc/apt/apt.conf* (in some system on location such as */etc/apt/apt.conf.d/{something-proxy}*) the following code:
 
 ```bash
 Acquire::http:proxy "http://<<proxyuser:proxypassword>@><proxy.example.com>:<proxyport>/";


### PR DESCRIPTION
Added documentation about how to configure a customer infrastructure to use a proxy and their docker daemon to respect and use the proxy configuration to.